### PR TITLE
Add CRM setup script

### DIFF
--- a/codex-root/docs/MONICA-CRM.md
+++ b/codex-root/docs/MONICA-CRM.md
@@ -26,6 +26,12 @@ Run:
 docker compose exec monica php artisan migrate
 ```
 
+Alternatively you can automate steps 2 and 3 by running:
+
+```bash
+scripts/setup_crm.sh
+```
+
 ### 4️⃣ Run Monica CRM
 
 ```bash

--- a/codex-root/scripts/setup_crm.sh
+++ b/codex-root/scripts/setup_crm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# This script automates the steps described in docs/MONICA-CRM.md
+# It clones a monica CRM fork, applies patches and runs migrations.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="$ROOT_DIR/monica-crm"
+REPO_URL="${1:-https://github.com/YOURUSER/monica-crm.git}"
+
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "Cloning Monica CRM repo from $REPO_URL"
+  git clone "$REPO_URL" "$TARGET_DIR"
+else
+  echo "Target directory $TARGET_DIR already exists, skipping clone"
+fi
+
+# Copy patch files
+cp "$ROOT_DIR/monica-crm-patches/app/Models/Company.php" "$TARGET_DIR/app/Models/" || true
+cp "$ROOT_DIR/monica-crm-patches/app/Models/Deal.php" "$TARGET_DIR/app/Models/" || true
+mkdir -p "$TARGET_DIR/database/migrations"
+cp "$ROOT_DIR/monica-crm-patches/database/migrations"/*.php "$TARGET_DIR/database/migrations/" || true
+
+# Run migrations inside docker
+if command -v docker >/dev/null 2>&1; then
+  echo "Running migrations via docker compose"
+  docker compose -f "$ROOT_DIR/docker-compose.yml" exec monica php artisan migrate
+else
+  echo "Docker not found. Please run migrations manually inside the container."
+fi
+
+echo "Setup complete. You can now run: docker compose -f \"$ROOT_DIR/docker-compose.yml\" up --build"


### PR DESCRIPTION
## Summary
- document using `scripts/setup_crm.sh` to automate CRM patching
- add `scripts/setup_crm.sh` for cloning and patching a Monica fork

## Testing
- `npm test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b49168f48326a6061225446a9a89